### PR TITLE
fix: add main import

### DIFF
--- a/packages/core/features/package.json
+++ b/packages/core/features/package.json
@@ -17,6 +17,7 @@
     },
     "type": "module",
     "sideEffects": false,
+    "main": "./lib/esm/index.js",
     "module": "./lib/esm/index.js",
     "types": "./lib/types/index.d.ts",
     "exports": {


### PR DESCRIPTION
While probably not technically legal, we need  this for mobile & babel to work properly.