### PR TITLE
chore: slim down wallet standard util package

### DIFF
--- a/packages/core/_/package.json
+++ b/packages/core/_/package.json
@@ -30,9 +30,9 @@
         "package": "shx mkdir -p lib/cjs && shx echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json"
     },
     "dependencies": {
-        "@solana/wallet-standard-chains": "workspace:^",
-        "@solana/wallet-standard-features": "workspace:^",
-        "@solana/wallet-standard-util": "workspace:^"
+        "@exodus/solana-wallet-standard-chains": "workspace:^",
+        "@exodus/solana-wallet-standard-features": "workspace:^",
+        "@exodus/solana-wallet-standard-util": "workspace:^"
     },
     "devDependencies": {
         "shx": "^0.3.4"

--- a/packages/core/_/src/index.ts
+++ b/packages/core/_/src/index.ts
@@ -1,3 +1,3 @@
-export * from '@solana/wallet-standard-chains';
-export * from '@solana/wallet-standard-features';
-export * from '@solana/wallet-standard-util';
+export * from '@exodus/solana-wallet-standard-chains';
+export * from '@exodus/solana-wallet-standard-features';
+export * from '@exodus/solana-wallet-standard-util';

--- a/packages/core/chains/package.json
+++ b/packages/core/chains/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "@solana/wallet-standard-chains",
-    "version": "1.1.1",
+    "name": "@exodus/solana-wallet-standard-chains",
+    "version": "1.1.1-exodus.0",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",
@@ -8,23 +8,19 @@
         "access": "public"
     },
     "files": [
-        "lib",
-        "src",
-        "LICENSE"
+        "lib/esm",
+        "lib/types",
+        "!**/*.map"
     ],
     "engines": {
         "node": ">=16"
     },
     "type": "module",
     "sideEffects": false,
-    "main": "./lib/cjs/index.js",
+    "main": "./lib/esm/index.js",
     "module": "./lib/esm/index.js",
     "types": "./lib/types/index.d.ts",
-    "exports": {
-        "require": "./lib/cjs/index.js",
-        "import": "./lib/esm/index.js",
-        "types": "./lib/types/index.d.ts"
-    },
+    "exports": "./lib/esm/index.js",
     "scripts": {
         "clean": "shx mkdir -p lib && shx rm -rf lib",
         "package": "shx mkdir -p lib/cjs && shx echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json"

--- a/packages/core/features/package.json
+++ b/packages/core/features/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@exodus/solana-wallet-standard-features",
-    "version": "1.3.0",
+    "version": "1.3.0-exodus.0",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/ExodusMovement/solana-wallet-standard/",
     "license": "Apache-2.0",

--- a/packages/core/util/package.json
+++ b/packages/core/util/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@exodus/solana-wallet-standard-util",
-    "version": "1.1.2-exodus.2",
+    "version": "1.1.2-exodus.3",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/core/util/package.json
+++ b/packages/core/util/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@exodus/solana-wallet-standard-util",
-    "version": "1.1.2-exodus.1",
+    "version": "1.1.2-exodus.2",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/core/util/package.json
+++ b/packages/core/util/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@exodus/wallet-standard-util",
+    "name": "@exodus/solana-wallet-standard-util",
     "version": "1.1.2-exodus.0",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",

--- a/packages/core/util/package.json
+++ b/packages/core/util/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "@solana/wallet-standard-util",
-    "version": "1.1.2",
+    "name": "@exodus/wallet-standard-util",
+    "version": "1.1.2-exodus.0",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",
@@ -8,23 +8,19 @@
         "access": "public"
     },
     "files": [
-        "lib",
-        "src",
-        "LICENSE"
+        "lib/esm",
+        "lib/types",
+        "!**/*.map"
     ],
     "engines": {
         "node": ">=16"
     },
     "type": "module",
     "sideEffects": false,
-    "main": "./lib/cjs/index.js",
+    "main": "./lib/esm/index.js",
     "module": "./lib/esm/index.js",
     "types": "./lib/types/index.d.ts",
-    "exports": {
-        "require": "./lib/cjs/index.js",
-        "import": "./lib/esm/index.js",
-        "types": "./lib/types/index.d.ts"
-    },
+    "exports": "./lib/esm/index.js",
     "scripts": {
         "clean": "shx mkdir -p lib && shx rm -rf lib",
         "package": "shx mkdir -p lib/cjs && shx echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",

--- a/packages/core/util/package.json
+++ b/packages/core/util/package.json
@@ -28,8 +28,8 @@
     },
     "dependencies": {
         "@noble/curves": "^1.8.0",
-        "@solana/wallet-standard-chains": "workspace:^",
-        "@solana/wallet-standard-features": "workspace:^"
+        "@exodus/solana-wallet-standard-chains": "workspace:^",
+        "@exodus/solana-wallet-standard-features": "workspace:^"
     },
     "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/packages/core/util/package.json
+++ b/packages/core/util/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@exodus/solana-wallet-standard-util",
-    "version": "1.1.2-exodus.0",
+    "version": "1.1.2-exodus.1",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/solana-labs/wallet-standard",
     "license": "Apache-2.0",

--- a/packages/core/util/src/commitment.ts
+++ b/packages/core/util/src/commitment.ts
@@ -1,4 +1,4 @@
-import type { SolanaTransactionCommitment } from '@solana/wallet-standard-features';
+import type { SolanaTransactionCommitment } from '@exodus/solana-wallet-standard-features';
 
 // Copied from @solana/web3.js
 type Commitment = 'processed' | 'confirmed' | 'finalized' | 'recent' | 'single' | 'singleGossip' | 'root' | 'max';

--- a/packages/core/util/src/endpoint.ts
+++ b/packages/core/util/src/endpoint.ts
@@ -1,10 +1,10 @@
-import type { SolanaChain } from '@solana/wallet-standard-chains';
+import type { SolanaChain } from '@exodus/solana-wallet-standard-chains';
 import {
     SOLANA_DEVNET_CHAIN,
     SOLANA_LOCALNET_CHAIN,
     SOLANA_MAINNET_CHAIN,
     SOLANA_TESTNET_CHAIN,
-} from '@solana/wallet-standard-chains';
+} from '@exodus/solana-wallet-standard-chains';
 
 /** TODO: docs */
 export const MAINNET_ENDPOINT = 'https://api.mainnet-beta.solana.com';

--- a/packages/core/util/src/signIn.ts
+++ b/packages/core/util/src/signIn.ts
@@ -1,4 +1,4 @@
-import type { SolanaSignInInput, SolanaSignInOutput } from '@solana/wallet-standard-features';
+import type { SolanaSignInInput, SolanaSignInOutput } from '@exodus/solana-wallet-standard-features';
 import { verifyMessageSignature } from './signMessage.js';
 import { arraysEqual } from './util.js';
 

--- a/packages/core/util/src/signMessage.ts
+++ b/packages/core/util/src/signMessage.ts
@@ -1,5 +1,5 @@
 import { ed25519 } from '@noble/curves/ed25519';
-import type { SolanaSignMessageInput, SolanaSignMessageOutput } from '@solana/wallet-standard-features';
+import type { SolanaSignMessageInput, SolanaSignMessageOutput } from '@exodus/solana-wallet-standard-features';
 import { bytesEqual } from './util.js';
 
 /**

--- a/packages/wallet-adapter/base/package.json
+++ b/packages/wallet-adapter/base/package.json
@@ -35,9 +35,9 @@
     },
     "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23",
-        "@solana/wallet-standard-chains": "workspace:^",
-        "@solana/wallet-standard-features": "workspace:^",
-        "@solana/wallet-standard-util": "workspace:^",
+        "@exodus/solana-wallet-standard-chains": "workspace:^",
+        "@exodus/solana-wallet-standard-features": "workspace:^",
+        "@exodus/solana-wallet-standard-util": "workspace:^",
         "@wallet-standard/app": "^1.1.0",
         "@wallet-standard/base": "^1.1.0",
         "@wallet-standard/features": "^1.1.0",

--- a/packages/wallet-adapter/base/src/adapter.ts
+++ b/packages/wallet-adapter/base/src/adapter.ts
@@ -30,8 +30,8 @@ import {
     SolanaSignMessage,
     SolanaSignTransaction,
     type SolanaSignTransactionFeature,
-} from '@solana/wallet-standard-features';
-import { getChainForEndpoint, getCommitment } from '@solana/wallet-standard-util';
+} from '@exodus/solana-wallet-standard-features';
+import { getChainForEndpoint, getCommitment } from '@exodus/solana-wallet-standard-util';
 import type { Connection, TransactionSignature } from '@solana/web3.js';
 import { PublicKey, Transaction, VersionedTransaction } from '@solana/web3.js';
 import type { WalletAccount } from '@wallet-standard/base';

--- a/packages/wallet-adapter/base/src/wallet.ts
+++ b/packages/wallet-adapter/base/src/wallet.ts
@@ -1,5 +1,5 @@
 import { type Adapter, isVersionedTransaction, WalletReadyState } from '@solana/wallet-adapter-base';
-import { isSolanaChain, type SolanaChain } from '@solana/wallet-standard-chains';
+import { isSolanaChain, type SolanaChain } from '@exodus/solana-wallet-standard-chains';
 import {
     SolanaSignAndSendTransaction,
     type SolanaSignAndSendTransactionFeature,
@@ -18,8 +18,8 @@ import {
     type SolanaSignTransactionMethod,
     type SolanaSignTransactionOutput,
     type SolanaTransactionVersion,
-} from '@solana/wallet-standard-features';
-import { getEndpointForChain } from '@solana/wallet-standard-util';
+} from '@exodus/solana-wallet-standard-features';
+import { getEndpointForChain } from '@exodus/solana-wallet-standard-util';
 import { Connection, Transaction, VersionedTransaction } from '@solana/web3.js';
 import { getWallets } from '@wallet-standard/app';
 import type { Wallet, WalletIcon } from '@wallet-standard/base';

--- a/packages/wallets/ghost/package.json
+++ b/packages/wallets/ghost/package.json
@@ -26,7 +26,7 @@
         "build": "npm run clean && npm run tsc && npm run package"
     },
     "dependencies": {
-        "@solana/wallet-standard-features": "workspace:^",
+        "@exodus/solana-wallet-standard-features": "workspace:^",
         "@solana/web3.js": "^1.98.0",
         "@wallet-standard/base": "^1.1.0",
         "@wallet-standard/features": "^1.1.0",

--- a/packages/wallets/ghost/src/account.ts
+++ b/packages/wallets/ghost/src/account.ts
@@ -4,7 +4,7 @@ import {
     SolanaSignAndSendTransaction,
     SolanaSignMessage,
     SolanaSignTransaction,
-} from '@solana/wallet-standard-features';
+} from '@exodus/solana-wallet-standard-features';
 import type { WalletAccount } from '@wallet-standard/base';
 import { SOLANA_CHAINS } from './solana.js';
 

--- a/packages/wallets/ghost/src/solana.ts
+++ b/packages/wallets/ghost/src/solana.ts
@@ -1,4 +1,4 @@
-// This is copied from @solana/wallet-standard-chains
+// This is copied from @exodus/solana-wallet-standard-chains
 
 import type { IdentifierString } from '@wallet-standard/base';
 import type { Transaction, VersionedTransaction } from '@solana/web3.js';

--- a/packages/wallets/ghost/src/wallet.ts
+++ b/packages/wallets/ghost/src/wallet.ts
@@ -15,7 +15,7 @@ import {
     type SolanaSignTransactionFeature,
     type SolanaSignTransactionMethod,
     type SolanaSignTransactionOutput,
-} from '@solana/wallet-standard-features';
+} from '@exodus/solana-wallet-standard-features';
 import type { Transaction } from '@solana/web3.js';
 import { VersionedTransaction } from '@solana/web3.js';
 import type { Wallet } from '@wallet-standard/base';

--- a/packages/wallets/ghost/src/window.ts
+++ b/packages/wallets/ghost/src/window.ts
@@ -1,4 +1,4 @@
-import { type SolanaSignInInput, type SolanaSignInOutput } from '@solana/wallet-standard-features';
+import { type SolanaSignInInput, type SolanaSignInOutput } from '@exodus/solana-wallet-standard-features';
 import type { PublicKey, SendOptions, Transaction, TransactionSignature, VersionedTransaction } from '@solana/web3.js';
 
 export interface GhostEvent {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,13 +81,13 @@ importers:
 
   packages/core/_:
     dependencies:
-      '@solana/wallet-standard-chains':
+      '@exodus/solana-wallet-standard-chains':
         specifier: workspace:^
         version: link:../chains
-      '@solana/wallet-standard-features':
+      '@exodus/solana-wallet-standard-features':
         specifier: workspace:^
         version: link:../features
-      '@solana/wallet-standard-util':
+      '@exodus/solana-wallet-standard-util':
         specifier: workspace:^
         version: link:../util
     devDependencies:
@@ -120,15 +120,15 @@ importers:
 
   packages/core/util:
     dependencies:
+      '@exodus/solana-wallet-standard-chains':
+        specifier: workspace:^
+        version: link:../chains
+      '@exodus/solana-wallet-standard-features':
+        specifier: workspace:^
+        version: link:../features
       '@noble/curves':
         specifier: ^1.8.0
         version: 1.8.0
-      '@solana/wallet-standard-chains':
-        specifier: workspace:^
-        version: link:../chains
-      '@solana/wallet-standard-features':
-        specifier: workspace:^
-        version: link:../features
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
@@ -158,18 +158,18 @@ importers:
 
   packages/wallet-adapter/base:
     dependencies:
+      '@exodus/solana-wallet-standard-chains':
+        specifier: workspace:^
+        version: link:../../core/chains
+      '@exodus/solana-wallet-standard-features':
+        specifier: workspace:^
+        version: link:../../core/features
+      '@exodus/solana-wallet-standard-util':
+        specifier: workspace:^
+        version: link:../../core/util
       '@solana/wallet-adapter-base':
         specifier: ^0.9.23
         version: 0.9.23(@solana/web3.js@1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/wallet-standard-chains':
-        specifier: workspace:^
-        version: link:../../core/chains
-      '@solana/wallet-standard-features':
-        specifier: workspace:^
-        version: link:../../core/features
-      '@solana/wallet-standard-util':
-        specifier: workspace:^
-        version: link:../../core/util
       '@wallet-standard/app':
         specifier: ^1.1.0
         version: 1.1.0
@@ -220,7 +220,7 @@ importers:
 
   packages/wallets/ghost:
     dependencies:
-      '@solana/wallet-standard-features':
+      '@exodus/solana-wallet-standard-features':
         specifier: workspace:^
         version: link:../../core/features
       '@solana/web3.js':


### PR DESCRIPTION
Slims `@solana/wallet-standard-util` down to reduce the audit effort and re-publish as `@exodus/wallet-standard-util`

Towards https://github.com/ExodusMovement/passkeys/issues/3204