### PR TITLE
fix: use types conditional in exports

### DIFF
--- a/packages/core/features/package.json
+++ b/packages/core/features/package.json
@@ -21,7 +21,8 @@
     "module": "./lib/esm/index.js",
     "types": "./lib/types/index.d.ts",
     "exports": {
-        ".": "./lib/esm/index.js"
+        "import": "./lib/esm/index.js",
+        "types": "./lib/types/index.d.ts"
     },
     "scripts": {
         "clean": "shx mkdir -p lib && shx rm -rf lib",


### PR DESCRIPTION
## Summary

When using export conditionals and a non-standard location for types, TypeScript requires a `types` [conditional to actually use the types](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package.json-exports-imports-and-self-referencing). Otherwise, it will report that it found the types but can't use them due to `exports` restrictions:

> Could not find a declaration file for module implicitly has an 'any' type. There are types at {path}, but this result could not be resolved when respecting package.json "exports". The library may need to update its package.json or typings.

Towards: https://github.com/ExodusMovement/passkeys/issues/3405