### PR TITLE
chore: release 1.3.0-exodus.1

### DIFF
--- a/packages/core/features/package.json
+++ b/packages/core/features/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@exodus/solana-wallet-standard-features",
-    "version": "1.3.0-exodus.0",
+    "version": "1.3.0-exodus.1",
     "author": "Solana Maintainers <maintainers@solana.foundation>",
     "repository": "https://github.com/ExodusMovement/solana-wallet-standard/",
     "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

Prepares the manifest to release version `1.3.0-exodus.1`, which adds the types fix for the `@exodus/solana-wallet-standard-features` package.

Towards: https://github.com/ExodusMovement/passkeys/issues/3405