### PR TITLE
ci: pin GitHub Actions hashes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           publish: pnpm release
         env:


### PR DESCRIPTION
  ## 📝 Summary

  Pin GitHub Actions used in CI workflows to full commit SHAs.

  This removes floating action references and reduces supply-chain risk by ensuring workflow execution uses reviewed, immutable upstream revisions instead of tags that can be moved.